### PR TITLE
Fix include path for CI/phpunit configuration

### DIFF
--- a/DefaultLocalSettings.php
+++ b/DefaultLocalSettings.php
@@ -78,8 +78,8 @@ $wgWBRepoSettings['maxSerializedEntitySize'] = 0;
 $wgWBClientSettings['repoSiteId'] = 'wikidatawikidev';
 
 if ( defined( 'MW_PHPUNIT_TEST' ) ) {
-	require_once './extensions/Wikibase/repo/config/Wikibase.ci.php';
-	require_once './extensions/Wikibase/client/config/WikibaseClient.ci.php';
+	require_once "$IP/extensions/Wikibase/repo/config/Wikibase.ci.php";
+	require_once "$IP/extensions/Wikibase/client/config/WikibaseClient.ci.php";
 }
 // https://doc.wikimedia.org/Wikibase/master/php/md_docs_topics_options.html#common_entitySources
 // https://doc.wikimedia.org/Wikibase/master/php/md_docs_topics_entitysources.html


### PR DESCRIPTION
The include path for the Phpunit configuration files is described with a local path reference ("./") that only works if the script is run from the root directory. Replacing "./" with "$IP/" makes the script portable, which fixes the support for running tests from the IDE